### PR TITLE
Fix canGoToNext calculation

### DIFF
--- a/src/Agile.vue
+++ b/src/Agile.vue
@@ -150,7 +150,7 @@
 			},
 
 			canGoToNext: function () {
-				return (this.settings.infinite || this.currentSlide < this.countSlides - 1)
+				return (this.settings.infinite || this.currentSlide < this.countSlides - this.settings.slidesToShow)
 			},
 
 			countSlides: function () {


### PR DESCRIPTION
Disable next button if the last slide appears on the right of the diaporama